### PR TITLE
add version check to append comment attribute

### DIFF
--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -273,6 +273,33 @@ def main():
         if rc != 0:
             module.fail_json(msg=err or out)
 
+    def ufw_version():
+        """
+        Returns the major and minor version of ufw installed on the system.
+        """
+        rc, out, err = module.run_command("%s --version" % ufw_bin)
+        if rc != 0:
+            module.fail_json(
+                msg="Failed to get ufw version.", rc=rc, out=out, err=err
+            )
+
+        lines = [x for x in out.split('\n') if x.strip() != '']
+        if len(lines) == 0:
+            module.fail_json(msg="Failed to get ufw version.", rc=0, out=out)
+
+        matches = re.search(r'^ufw.+(\d+)\.(\d+)(?:\.(\d+))?.*$', lines[0])
+        if matches is None:
+            module.fail_json(msg="Failed to get ufw version.", rc=0, out=out)
+
+        # Convert version to numbers
+        major = int(matches.group(1))
+        minor = int(matches.group(2))
+        rev   = 0
+        if matches.group(3) is not None:
+            rev = int(matches.group(3))
+
+        return major, minor, rev
+
     params = module.params
 
     # Ensure at least one of the command arguments are given
@@ -329,7 +356,11 @@ def main():
 
                 value = params[key]
                 cmd.append([value, template % (value)])
-            cmd.append([params['comment'], "comment '%s'" % params['comment']])
+                
+            ufw_major, ufw_minor, _ = ufw_version()
+            # comment is supported only in ufw version after 0.35
+            if (ufw_major == 0 and ufw_minor >= 35) or ufw_major > 0:
+                cmd.append([params['comment'], "comment '%s'" % params['comment']])
 
             execute(cmd)
 


### PR DESCRIPTION
add version check to append comment attribute

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module ufw

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /root/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### SUMMARY
Just a small patch to get UFW version and test against before adding `comment` attrbute
